### PR TITLE
Add job-dsl plugin to Jenkins master

### DIFF
--- a/jenkins-master/plugins.txt
+++ b/jenkins-master/plugins.txt
@@ -20,6 +20,7 @@ greenballs
 htmlpublisher
 http_request
 jacoco
+job-dsl
 junit
 kubernetes
 lockable-resources


### PR DESCRIPTION
This plugin is required to create Jobs via the Config as Code plugin.