### PR TITLE
remove space separation on plugin loading

### DIFF
--- a/jenkins-master/Dockerfile
+++ b/jenkins-master/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get -y --no-install-recommends install docker-ce && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*  && \
-    /usr/local/bin/install-plugins.sh $(tr '\n' ' ' < /usr/share/jenkins/ref/plugins.txt) && \ 
+    /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt && \ 
     chown -R jenkins /usr/share/jenkins/ref && \
     echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 


### PR DESCRIPTION
as of https://github.com/jenkinsci/docker#script-usage this is not needed