### PR TITLE
Do not truncate log when uploading a file into a transport request

### DIFF
--- a/node-rfc/run_rfc_task.js
+++ b/node-rfc/run_rfc_task.js
@@ -2,6 +2,7 @@
 
 var rfc = require("node-rfc");
 var fs = require("fs");
+var util = require('util');
 
 module.exports = function(grunt) {
 
@@ -138,6 +139,7 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask("uploadToABAP", "Uploads the application to the ABAP System", function(transportRequest) {
+        util.inspect.defaultOptions.maxArrayLength = null;
         grunt.log.writeln("Uploading to ABAP");
         if (!transportRequest) {
             grunt.log.errorlns("No Transport request specified.");


### PR DESCRIPTION
This is the minimal change in order to resolve the issue with the truncated log.
Would be reasonable to set that also for creating and releasing a transport request.