### PR TITLE
Fix cx-server does not start when no custom-environment.list

### DIFF
--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -16,12 +16,11 @@ else
     echo No interactive terminal, run Docker without '-it' flag
 fi
 
-env_file_command=''
+custom_env_file_parameter=''
 env_file='custom-environment.list'
 
 if [ -f ${env_file} ]; then
-    env_file_command="--env-file $env_file"
-    echo ${env_file_command}
+    custom_env_file_parameter="--env-file $env_file"
 fi
 
 # These braces ensure that the block in them cannot be overridden by updating this file on the fly.
@@ -35,7 +34,7 @@ fi
         --env DEVELOPER_MODE \
         --env host_os=unix \
         --env cx_server_path="${PWD}" \
-        ${env_file_command} \
+        ${custom_env_file_parameter} \
         ppiper/cx-server-companion /cx-server/cx-server-companion.sh "$@"
     exit $?
 }

--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -16,6 +16,14 @@ else
     echo No interactive terminal, run Docker without '-it' flag
 fi
 
+env_file_command=''
+env_file='custom-environment.list'
+
+if [ -f ${env_file} ]; then
+    env_file_command="--env-file $env_file"
+    echo ${env_file_command}
+fi
+
 # These braces ensure that the block in them cannot be overridden by updating this file on the fly.
 # The exit inside protects against unintended effect when the new script file is bigger than its old version.
 # See: https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running
@@ -27,7 +35,7 @@ fi
         --env DEVELOPER_MODE \
         --env host_os=unix \
         --env cx_server_path="${PWD}" \
-        --env-file custom-environment.list \
+        ${env_file_command} \
         ppiper/cx-server-companion /cx-server/cx-server-companion.sh "$@"
     exit $?
 }

--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Ensure that docker is installed
-command -v docker > /dev/null 2>&1 || { echo >&2 "Docker does not seem to be installed. Please install docker and ensure that the docker command is included in \$PATH."; exit 1; }
+# Ensure that Docker is installed
+command -v docker > /dev/null 2>&1 || { echo >&2 "Docker does not seem to be installed. Please install Docker and ensure that the 'docker' command is included in \$PATH."; exit 1; }
 
 source server.cfg
 
@@ -16,25 +16,25 @@ else
     echo No interactive terminal, run Docker without '-it' flag
 fi
 
-custom_env_file_parameter=''
-env_file='custom-environment.list'
+docker_arguments=(--rm
+    "${DOCKER_IT_FLAG}"
+    --mount "source=${PWD},target=/cx-server/mount,type=bind"
+    --workdir /cx-server/mount
+    --volume /var/run/docker.sock:/var/run/docker.sock
+    --env DEVELOPER_MODE
+    --env "host_os=unix"
+    --env "cx_server_path=${PWD}")
 
+# Environment file is required for integration tests
+readonly env_file='custom-environment.list'
 if [ -f ${env_file} ]; then
-    custom_env_file_parameter="--env-file $env_file"
+    docker_arguments+=(--env-file "${env_file}")
 fi
 
 # These braces ensure that the block in them cannot be overridden by updating this file on the fly.
 # The exit inside protects against unintended effect when the new script file is bigger than its old version.
 # See: https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running
 {
-    docker run --rm ${DOCKER_IT_FLAG} \
-        --mount source="${PWD},target=/cx-server/mount,type=bind" \
-        --workdir /cx-server/mount \
-        --volume /var/run/docker.sock:/var/run/docker.sock \
-        --env DEVELOPER_MODE \
-        --env host_os=unix \
-        --env cx_server_path="${PWD}" \
-        ${custom_env_file_parameter} \
-        ppiper/cx-server-companion /cx-server/cx-server-companion.sh "$@"
+    docker run "${docker_arguments[@]}" ppiper/cx-server-companion /cx-server/cx-server-companion.sh "$@"
     exit $?
 }


### PR DESCRIPTION
This PR fixes the bug reported in #50 with checking if the file exists and using it if yes. Otherwise the parameter won't be passed to the docker run cmd.