### PR TITLE
Add cobertura Plugin

### DIFF
--- a/jenkins-master/plugins.txt
+++ b/jenkins-master/plugins.txt
@@ -4,9 +4,10 @@ blueocean
 build-monitor-plugin
 build-timeout
 checkmarx
+cobertura
 command-launcher
 configuration-as-code
-configuration-as-code-support 
+configuration-as-code-support
 credentials
 credentials-binding
 cucumber-testresult-plugin


### PR DESCRIPTION
We use in our JS Pipeline Cobertura for measuring CC.
This plugins displays a chart and fails the pipeline at certain thresholds.