### PR TITLE
Extend infrastructure tests to MTA builder image

### DIFF
--- a/infrastructure-tests/Jenkinsfile
+++ b/infrastructure-tests/Jenkinsfile
@@ -30,6 +30,8 @@ timeout(time: 5, unit: 'HOURS') {
                 jenkins.waitForSuccess('infrastructure-integration-test', 'infrastructure-integration-test')
             }, neoEnvironment: {
                 jenkins.waitForSuccess('infrastructure-integration-test', 'infrastructure-integration-test-neo')
+            }, cloudFoundryCap: {
+                jenkins.waitForSuccess('infrastructure-integration-test', 'infrastructure-integration-test-cap')
             }
         }
     }

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -19,7 +19,6 @@ find ../cx-server-companion -type f -exec sed -i -e 's/ppiper/localhost:5000\/pp
 
 # Copy over life cycle script for testing
 cp ../cx-server-companion/life-cycle-scripts/{cx-server,server.cfg} .
-echo "cache_enabled=false" >> server.cfg # Disable download cache because it does not seedup thing in this scenario
 mkdir -p jenkins-configuration
 cp testing-jenkins.yml jenkins-configuration
 

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -26,16 +26,19 @@ docker build -t localhost:5000/ppiper/jenkins-master:latest ../jenkins-master
 docker build -t localhost:5000/ppiper/cx-server-companion:latest ../cx-server-companion
 docker build -t localhost:5000/ppiper/cf-cli ../cf-cli
 docker build -t localhost:5000/ppiper/neo-cli ../neo-cli
+docker build -t localhost:5000/ppiper/mta-archive-builder ../mta-archive-builder
 
 docker tag localhost:5000/ppiper/jenkins-master:latest ppiper/jenkins-master:latest
 docker tag localhost:5000/ppiper/cx-server-companion:latest ppiper/cx-server-companion:latest
 docker tag localhost:5000/ppiper/cf-cli ppiper/cf-cli:latest
 docker tag localhost:5000/ppiper/neo-cli ppiper/neo-cli:latest
+docker tag localhost:5000/ppiper/mta-archive-builder ppiper/mta-archive-builder:latest
 
 docker push localhost:5000/ppiper/jenkins-master:latest
 docker push localhost:5000/ppiper/cx-server-companion:latest
 docker push localhost:5000/ppiper/cf-cli:latest
 docker push localhost:5000/ppiper/neo-cli:latest
+docker push localhost:5000/ppiper/mta-archive-builder:latest
 
 # Boot our unit-under-test Jenkins master instance using the `cx-server` script
 TEST_ENVIRONMENT=(CX_INFRA_IT_CF_USERNAME CX_INFRA_IT_CF_PASSWORD)

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -19,6 +19,7 @@ find ../cx-server-companion -type f -exec sed -i -e 's/ppiper/localhost:5000\/pp
 
 # Copy over life cycle script for testing
 cp ../cx-server-companion/life-cycle-scripts/{cx-server,server.cfg} .
+echo "cache_enabled=false" >> server.cfg # Disable download cache because it does not seedup thing in this scenario
 mkdir -p jenkins-configuration
 cp testing-jenkins.yml jenkins-configuration
 


### PR DESCRIPTION
This PR adds the MTA builder to the tested images. The source for this test is here https://github.com/SAP/cloud-s4-sdk-book/tree/infrastructure-integration-test-cap