### PR TITLE
container-structure-test: remove HaDoLint findings

### DIFF
--- a/container-structure-test/Dockerfile
+++ b/container-structure-test/Dockerfile
@@ -1,8 +1,9 @@
-FROM buildpack-deps:stretch-curl
+FROM gcr.io/kaniko-project/executor:debug as busybox
+FROM buildpack-deps:stretch-curl as executable
 RUN curl -L https://storage.googleapis.com/container-structure-test/v1.8.0/container-structure-test-linux-amd64 -o /container-structure-test && \
   chmod +x /container-structure-test
-FROM gcr.io/distroless/base:latest
-COPY --from=gcr.io/kaniko-project/executor:debug /busybox /busybox
-COPY --from=0 /container-structure-test /busybox/container-structure-test
+FROM gcr.io/distroless/base:latest as runner
+COPY --from=busybox /busybox /busybox
+COPY --from=executable /container-structure-test /busybox/container-structure-test
 ENV PATH $PATH:/busybox
 ENTRYPOINT ["/busybox/container-structure-test"]

--- a/container-structure-test/Dockerfile
+++ b/container-structure-test/Dockerfile
@@ -2,6 +2,7 @@ FROM gcr.io/kaniko-project/executor:debug as busybox
 FROM buildpack-deps:stretch-curl as executable
 RUN curl -L https://storage.googleapis.com/container-structure-test/v1.8.0/container-structure-test-linux-amd64 -o /container-structure-test && \
   chmod +x /container-structure-test
+# hadolint ignore=DL3007
 FROM gcr.io/distroless/base:latest as runner
 COPY --from=busybox /busybox /busybox
 COPY --from=executable /container-structure-test /busybox/container-structure-test


### PR DESCRIPTION
remove HaDoLint findings:
- [x] Dockerfile:4 DL3007 Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
- [x] Dockerfile:5 DL3022 COPY --from should reference a previously defined FROM alias
- [x] Dockerfile:6 DL3022 COPY --from should reference a previously defined FROM alias

related issue: #72