### PR TITLE
limit travis builds to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+  - master
 language: minimal
 services:
 - docker


### PR DESCRIPTION
Currently we build with two travis jobs at the same time (`pr`& `push`). This blocks additional executors, increases the *PR feedback time* and may lead to issues during deployment to the test space.


https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches