### PR TITLE
Install python2.7 for node-gyp

### DIFF
--- a/mta-archive-builder/Dockerfile
+++ b/mta-archive-builder/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update && \
     #
     apt-get install --yes --no-install-recommends \
       build-essential \
-      python-minimal && \
+      python2.7 && \
     #
     # Cleanup curl (was only needed for downloading artifacts)
     #


### PR DESCRIPTION
Seems like we need a "full" python install for some cases, cf https://github.com/nodejs/node-gyp/issues/1524