### PR TITLE
Configure path to python 2.7

### DIFF
--- a/mta-archive-builder/Dockerfile
+++ b/mta-archive-builder/Dockerfile
@@ -12,6 +12,8 @@ ENV MTA_JAR_LOCATION="${MTA_HOME}/lib/mta.jar"
 
 ENV M2_HOME=/opt/maven/apache-maven-${MAVEN_VERSION}
 
+ENV PYTHON /usr/bin/python2.7
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY scripts/mtaBuild.sh ${MTA_HOME}/bin/mtaBuild.sh


### PR DESCRIPTION
node-gyp does not find the python executable. This should fix it.

```
10:23:52  > node build.js
10:23:52  
10:23:52  { Error: Command failed: node-gyp configure
10:23:52  gyp ERR! configure error 
10:23:52  gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
10:23:52  gyp ERR! stack     at PythonFinder.failNoPython (/opt/nodejs/node-v10.13.0-linux-x64/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:484:19)
```