### PR TITLE
Just get the tag name for building the docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: cd jacoco-cli; docker build . --file Dockerfile --tag ppiper/jacoco-cli:${GITHUB_REF}
+      run: cd jacoco-cli; docker build . --file Dockerfile --tag ppiper/jacoco-cli:${GITHUB_REF##*/}
     - name: Push to Docker Hub
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        docker push ppiper/jacoco-cli:${GITHUB_REF}
+        docker push ppiper/jacoco-cli:${GITHUB_REF##*/}
         rm -f /home/runner/.docker/config.json


### PR DESCRIPTION
In release `v2` it failed to build because the variable contains the whole ref, not just the tag name as I assumed.

Solution found on  https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/td-p/31595